### PR TITLE
fix: discovery exception during reconnect

### DIFF
--- a/intg-androidtv/config.py
+++ b/intg-androidtv/config.py
@@ -78,7 +78,7 @@ class Devices:
         return None
 
     def update(self, atv: AtvDevice) -> bool:
-        """Update a configured Android TV device."""
+        """Update a configured Android TV device and persist configuration."""
         for item in self._config:
             if item.id == atv.id:
                 item.address = atv.address

--- a/intg-androidtv/discover.py
+++ b/intg-androidtv/discover.py
@@ -44,15 +44,18 @@ async def android_tvs(timeout: int = 10) -> list[dict[str, str]]:
         else:
             _LOG.debug("No info for %s", name)
 
-    aiozc = AsyncZeroconf()
-    services = ["_androidtvremote2._tcp.local."]
-    _LOG.debug("Discovering Android TV Remote Services")
+    try:
+        _LOG.debug("Discovering Android TV Remote Services")
+        # warning: this can throw `OSError: [Errno 19] No such device` if the interface is not ready yet
+        aiozc = AsyncZeroconf()
+        services = ["_androidtvremote2._tcp.local."]
 
-    aiobrowser = AsyncServiceBrowser(aiozc.zeroconf, services, handlers=[on_service_state_changed])
+        aiobrowser = AsyncServiceBrowser(aiozc.zeroconf, services, handlers=[on_service_state_changed])
 
-    await asyncio.sleep(timeout)
-    await aiobrowser.async_cancel()
-    await aiozc.async_close()
-    _LOG.debug("Discovery finished")
-
+        await asyncio.sleep(timeout)
+        await aiobrowser.async_cancel()
+        await aiozc.async_close()
+        _LOG.debug("Discovery finished")
+    except OSError as ex:
+        _LOG.error("Failed to start discovery: %s", ex)
     return discovered_android_tvs

--- a/intg-androidtv/setup_flow.py
+++ b/intg-androidtv/setup_flow.py
@@ -70,8 +70,6 @@ async def driver_setup_handler(msg: SetupDriver) -> SetupAction:
     # if isinstance(msg, UserConfirmationResponse):
     #     return handle_user_confirmation(msg)
 
-    # TODO setup abort message: reset _setup_step to INIT. Requires intg library enhancement
-
     return SetupError()
 
 
@@ -156,7 +154,7 @@ async def handle_user_data_choice(msg: UserDataResponse) -> RequestUserInput | S
 
     if _pairing_android_tv is None:
         # Setup process was cancelled
-        return
+        return SetupError()
 
     _LOG.info("Pairing process begin")
 


### PR DESCRIPTION
After a device wakeup, the network interface might not be ready yet. Zeroconf throws an OSError in this case which will kill the reconnect task and the integration will never be able to connect again.