### PR TITLE
ci: verify driver.json version tag with git version tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+        with:
+          # History of 200 should be more than enough to calculate commit count since last release tag.
+          fetch-depth: 200
+
+      - name: Fetch all tags to determine version
+        run: |
+          git fetch origin +refs/tags/*:refs/tags/*
+          echo "VERSION=$(git describe --match "v[0-9]*" --tags HEAD --always)" >> $GITHUB_ENV
+
+      - name: Verify driver.json version for release build
+        if: contains(github.ref, 'tags/v')
+        run: |
+          DRIVER_VERSION="v$(jq .version -r driver.json)"
+          if [ "${{ env.VERSION }}" != "$DRIVER_VERSION" ]; then
+            echo "Version in driver.json ($DRIVER_VERSION) doesn't match git version tag (${{ env.VERSION }})!"
+            exit 1
+          fi
+
       - name: Prepare
         run: |
           sudo apt-get update && sudo apt-get install -y qemu binfmt-support qemu-user-static
@@ -36,11 +53,6 @@ jobs:
               python -m pip install -r requirements.txt && \
               pyinstaller --clean --onefile --name intg-androidtv intg-androidtv/driver.py"
 
-      - name: Fetch all tags to determine version
-        run: |
-          git fetch origin +refs/tags/*:refs/tags/*
-          echo "VERSION=$(git describe --match "v[0-9]*" --tags HEAD --always)" >> $GITHUB_ENV
-          
       - name: Add version
         run: |
           mkdir -p artifacts


### PR DESCRIPTION
Abort release build (having a git version tag) if driver.json version doesn't match.

Closes #17 