### PR TITLE
fix: new HBO MAX app mapping

### DIFF
--- a/intg-androidtv/apps.py
+++ b/intg-androidtv/apps.py
@@ -5,7 +5,7 @@ Apps = {
     "Prime Video": {"url": "https://app.primevideo.com"},
     "Plex": {"url": "plex://"},
     "Netflix": {"url": "netflix://"},
-    "HBO Max": {"url": "https://play.hbomax.com"},
+    "HBO Max": {"url": "https://play.max.com"},
     "Emby": {"url": "embyatv://tv.emby.embyatv/startapp"},
     "Disney+": {"url": "https://www.disneyplus.com"},
     "Apple TV": {"url": "https://tv.apple.com"},
@@ -49,6 +49,7 @@ IdMappings = {
     "com.valvesoftware.steamlink": "Steam Link",
     "org.videolan.vlc": "VLC",
     "com.ziggo.tv": "Ziggo GO TV",
+    "com.wbd.stream": "HBO Max",
 }
 
 # Application-ID substring mappings to friendly names
@@ -56,7 +57,6 @@ IdMappings = {
 NameMatching = {
     "youtube": "YouTube",
     "amazonvideo": "Prime Video",
-    "hbomax": "HBO Max",
     "apple": "Apple TV",
     "plex": "Plex",
     "kodi": "Kodi",


### PR DESCRIPTION
This should work with the new HBO max app.
Unfortunately I can't test it because the HBO app is geo blocked for me.

To be verified:
- app can be launched with new url
- app name shows up correctly once running with the new app id

Fixes #22