### PR TITLE
Remove reconnect delay after standby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Fixed
+- Remove reconnect delay after standby. Requires new Remote Two firmware ([unfoldedcircle/feature-and-bug-tracker#320](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/320)).
+
 ---
 
 ## v0.4.5 - 2024-01-09

--- a/intg-androidtv/apps.py
+++ b/intg-androidtv/apps.py
@@ -1,4 +1,5 @@
 """Application link and identifier mappings."""
+
 # Application launch links
 Apps = {
     "Youtube": {"url": "https://www.youtube.com"},

--- a/intg-androidtv/driver.py
+++ b/intg-androidtv/driver.py
@@ -60,8 +60,6 @@ async def on_exit_standby():
     Connect all Denon AVR instances.
     """
     _LOG.debug("Exit standby event: connecting device(s)")
-    # delay is only a temporary workaround, until the core verifies first that the network is up with an IP address
-    await asyncio.sleep(2)
 
     for configured in _configured_android_tvs.values():
         # start background task

--- a/intg-androidtv/inputs.py
+++ b/intg-androidtv/inputs.py
@@ -3,6 +3,7 @@ Input keycode mappings.
 
 See https://github.com/tronikos/androidtvremote2/blob/v0.0.14/src/androidtvremote2/remotemessage.proto#L681-L731
 """
+
 KeyCode = {
     "HDMI 1": "KEYCODE_TV_INPUT_HDMI_1",
     "HDMI 2": "KEYCODE_TV_INPUT_HDMI_2",


### PR DESCRIPTION
Requires new Remote Two firmware 1.7.x.

- Relates to unfoldedcircle/feature-and-bug-tracker#320