### PR TITLE
feat: allow to launch an app by app-id or -link

### DIFF
--- a/intg-androidtv/tv.py
+++ b/intg-androidtv/tv.py
@@ -572,21 +572,16 @@ class AndroidTv:
 
     async def select_source(self, source: str) -> ucapi.StatusCodes:
         """
-        Select a given source, either an app or input.
+        Select a given source, either a pre-defined app, input or by app-link/id.
 
-        :param source: the friendly source name
+        :param source: the friendly source name or an app-link / id
         """
         if source in apps.Apps:
-            return await self._launch_app(source)
+            return await self._launch_app(apps.Apps[source]["url"])
         if source in inputs.KeyCode:
             return await self._switch_input(source)
 
-        _LOG.warning(
-            "[%s] Unknown source parameter in select_source command: %s",
-            self.log_id,
-            source,
-        )
-        return ucapi.StatusCodes.BAD_REQUEST
+        return await self._launch_app(source)
 
     @async_handle_atvlib_errors
     async def _send_command(self, keycode: int | str, action: KeyPress = KeyPress.SHORT) -> ucapi.StatusCodes:
@@ -629,7 +624,7 @@ class AndroidTv:
     @async_handle_atvlib_errors
     async def _launch_app(self, app: str) -> ucapi.StatusCodes:
         """Launch an app on Android TV."""
-        self._atv.send_launch_app_command(apps.Apps[app]["url"])
+        self._atv.send_launch_app_command(app)
         return ucapi.StatusCodes.OK
 
     async def _switch_input(self, source: str) -> ucapi.StatusCodes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-androidtvremote2==0.0.15
+androidtvremote2==0.1.1
 ucapi==0.2.0


### PR DESCRIPTION
Any app can now be launched with the `select_source` command.
If the source is not defined as a pre-defined friendly-name app, it is directly passed to the app launch function.

Update androidtvremote2 to 0.1.1 to allow app-id & -link launching.

Starting an app with the REST Core-API on the Remote:
```
curl --location --request PUT 'http://$IP/api/entities/$ENTITY_ID/command' \
-u 'webconfigurator:$PIN' \
--header 'Content-Type: application/json' \
--data '{
  "cmd_id": "select_source",
  "params": {
    "source": "org.xbmc.kodi"
  }
}'
```

The web-configurator doesn't allow yet to enter free-text in the `select source` command and only shows the list of pre-defined apps:
<img width="402" alt="image" src="https://github.com/unfoldedcircle/integration-androidtv/assets/17356629/403be0dd-5345-4289-80f6-2b3b98074c9b">


This will be changed in a future update.

- Part of #47