### PR TITLE
Create a compatible custom integration installation archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
             bash -c \
             "cd /workspace && \
               python -m pip install -r requirements.txt && \
-              pyinstaller --clean --onefile --name intg-androidtv intg-androidtv/driver.py"
+              pyinstaller --clean --onedir --name intg-androidtv intg-androidtv/driver.py"
 
       - name: Add version
         run: |
@@ -65,7 +65,9 @@ jobs:
       - name: Prepare artifacts
         shell: bash
         run: |
-          cp dist/intg-androidtv artifacts/
+          mv dist/intg-androidtv artifacts/
+          mv artifacts/intg-androidtv artifacts/bin
+          mv artifacts/bin/intg-androidtv artifacts/bin/driver
           cp driver.json artifacts/
           cp -r config artifacts/
           echo "ARTIFACT_NAME=uc-intg-${{ env.INTG_NAME }}-${{ env.VERSION }}-aarch64" >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 _Changes in the next release_
 
+### Changed
+- Create a one-folder bundle with pyinstaller instead a one-file bundle to save resources.
+- Change archive format to the custom integration installation archive.
+- Change default `driver_id` value in `driver.json` to create a compatible custom installation archive.
+
 ---
 
 ## v0.6.1 - 2024-07-21

--- a/driver.json
+++ b/driver.json
@@ -1,5 +1,5 @@
 {
-	"driver_id": "uc_androidtv_driver",
+	"driver_id": "androidtv",
 	"version": "0.6.1",
 	"min_core_api": "0.20.0",
 	"name": { "en": "Android TV" },


### PR DESCRIPTION
- Create a one-folder bundle with PyInstaller instead a one-file bundle to save resources.
- Change archive format to the [custom integration installation archive](https://github.com/unfoldedcircle/core-api/blob/main/doc/integration-driver/driver-installation.md).
- Change default `driver_id` value in `driver.json` to create a compatible custom installation archive.