### PR TITLE
New media player attribute media_position_updated_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _Changes in the next release_
 - Google Cast for media info & seeking support. Contributed by @albaintor, thanks! ([#57](https://github.com/unfoldedcircle/integration-androidtv/pull/57))
   - This is currently a preview feature and must be enabled in the device configuration of the integration setup.
 - myCANAL application ([#55](https://github.com/unfoldedcircle/integration-androidtv/pull/55))
+- Set media player attribute "media_position_updated_at" ([feature-and-bug-tracker#443](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/443)).
 
 ### Changed
 - Add support article link and change setup description in first setup flow screen.

--- a/intg-androidtv/driver.py
+++ b/intg-androidtv/driver.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import os
 import sys
+from datetime import UTC, datetime
 from typing import Any
 
 import setup_flow
@@ -253,6 +254,7 @@ async def handle_android_tv_update(atv_id: str, update: dict[str, Any]) -> None:
 
     if MediaAttr.MEDIA_POSITION in update:
         attributes[MediaAttr.MEDIA_POSITION] = update[MediaAttr.MEDIA_POSITION]
+        attributes["media_position_updated_at"] = datetime.now(tz=UTC).isoformat()
 
     if MediaAttr.MEDIA_DURATION in update:
         attributes[MediaAttr.MEDIA_DURATION] = update[MediaAttr.MEDIA_DURATION]

--- a/intg-androidtv/tv.py
+++ b/intg-androidtv/tv.py
@@ -793,12 +793,14 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
             self._media_type = GOOGLE_CAST_MEDIA_TYPES_MAP.get(self._media_type, MediaType.VIDEO)
             update[MediaAttr.MEDIA_TYPE] = self._media_type
 
-        if status.images and len(status.images) > 0 and status.images[0] != self._media_image_url:
-            self._media_image_url = status.images[0]
+        if status.images and len(status.images) > 0 and status.images[0].url != self._media_image_url:
+            self._media_image_url = status.images[0].url
             update[MediaAttr.MEDIA_IMAGE_URL] = self._media_image_url
-        elif self._media_image_url:
+        elif not self._media_image_url:
             self._media_image_url = None
             update[MediaAttr.MEDIA_IMAGE_URL] = ""
+        else:
+            update[MediaAttr.MEDIA_IMAGE_URL] = self._media_image_url
 
         if update:
             _LOG.debug("[%s] Update remote with Chromecast info : %s", self.log_id, update)


### PR DESCRIPTION
Set the media position update timestamp in `media_position_updated_at`.
Relates to https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/443

Temporary fix for `media_image_url` when using the new Cast feature.
This needs to be reverted for the upcoming PR #60 which will change media image handling.