### PR TITLE
Update to Python 3.11.12 and pyinstaller Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ env:
   HASH_FILENAME: uc-intg-androidtv.hash
   BUILD_CHANGELOG: build-changelog.md
   # Python version to use in the builder image. See https://hub.docker.com/r/unfoldedcircle/r2-pyinstaller for possible versions.
-  PYTHON_VER: 3.11.6-0.2.0
+  PYTHON_VER: 3.11.12-0.3.0
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker run --rm --name builder \
     --platform=aarch64 \
     --user=$(id -u):$(id -g) \
     -v "$PWD":/workspace \
-    docker.io/unfoldedcircle/r2-pyinstaller:3.11.6  \
+    docker.io/unfoldedcircle/r2-pyinstaller:3.11.12  \
     bash -c \
       "python -m pip install -r requirements.txt && \
       pyinstaller --clean --onedir --name intg-androidtv intg-androidtv/driver.py"
@@ -88,7 +88,7 @@ On an aarch64 host platform, the build image can be run directly (and much faste
 docker run --rm --name builder \
     --user=$(id -u):$(id -g) \
     -v "$PWD":/workspace \
-    docker.io/unfoldedcircle/r2-pyinstaller:3.11.6  \
+    docker.io/unfoldedcircle/r2-pyinstaller:3.11.12  \
     bash -c \
       "python -m pip install -r requirements.txt && \
       pyinstaller --clean --onedir --name intg-androidtv intg-androidtv/driver.py"


### PR DESCRIPTION
The new r2-pyinstaller 3.11.12-0.3.0 image comes with an updated Python runtime and more importantly with up-to-date Python libraries like zeroconf and websockets.