### PR TITLE
Potential fix for failed reconnection

### DIFF
--- a/src/tv.py
+++ b/src/tv.py
@@ -12,7 +12,7 @@ import logging
 import os
 import socket
 import time
-from asyncio import AbstractEventLoop, timeout, Lock
+from asyncio import AbstractEventLoop, Lock, timeout
 from enum import IntEnum
 from functools import wraps
 from typing import Any, Awaitable, Callable, Concatenate, Coroutine, ParamSpec, TypeVar


### PR DESCRIPTION
Hi Markus,

following this reported issue : https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/526

I have replaced the test of the connection status (CONNECTING) with an asyncio lock to check after the connection task.
In that way we have these 2 requirements :
- Only one connection request at a time (skip new requests if connecting)
- Trigger a new connection task after wakeup  

As pointed out in the issue, the connection status is not reliable as it may be set to CONNECTING whereas it is not

But after second thoughts, I still wonder if this is the right way to do. The rootcause here is that things don't happen in the  right order :

1. Disconnection from driver requests disconnection to the android library and returns
2. You set the state to `DISCONNECTED`
3. But the android library triggers one last reconnection after in the connection loop after disconnection request -> this raise an event caught by your `AndroidTv::_is_available_updated` callback that resets the state back to `CONNECTING`
4. Then when the remote wakes up again, the `AndroidTv::connect` method will do nothing because it will skip task when status == `CONNECTING`
