### PR TITLE
Fix settings command on onn 4K pro

### DIFF
--- a/config/profiles/onn_Streaming_Device.json
+++ b/config/profiles/onn_Streaming_Device.json
@@ -30,10 +30,6 @@
     "context_menu": {
       "keycode": "DPAD_CENTER",
       "action": "LONG"
-    },
-    "settings": {
-      "keycode": "HOME",
-      "action": "LONG"
     }
   }
 }


### PR DESCRIPTION
I imagine overriding the settings command was needed at one point, but with the latest OS (Android 14, April 2025 security update), the onn 4K Pro now uses the standard `KEYCODE_SETTINGS` keycode to open settings. Sending a long-pressed home keycode does not work.