### PR TITLE
Fixed crash when Chromecast publish an artwork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-androidtvremote2==0.2.1
-ucapi==0.3.1
+androidtvremote2==0.2.3
+ucapi==0.3.2
 pyee~=13.0.0
 google_play_scraper==1.2.7
 pillow>=11.2.1
 requests>=2.32
-pychromecast~=14.0.7
+pychromecast~=14.0.9
 httpx~=0.28.1
 sanitize-filename~=1.2.0

--- a/src/tv.py
+++ b/src/tv.py
@@ -911,7 +911,7 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
 
         if status.images and len(status.images) > 0 and status.images[0].url != self._media_image_url:
             self._media_image_url = status.images[0].url
-            update[MediaAttr.MEDIA_IMAGE_URL] = await encode_icon_to_data_uri(self._media_image_url)
+            update[MediaAttr.MEDIA_IMAGE_URL] = self._media_image_url
             self._use_app_url = False
         else:
             self._media_image_url = None


### PR DESCRIPTION
I don't know why but the artwork URL submitted by Chromecast protocol was converted to base64 data. This is not necessary and makes the websocket crash when the data is too large, which is the case with one report on discord : https://discord.com/channels/553671366411288576/1144203300091199539/1423920294028120075

I just removed the conversion to binary 64 and tested successfully : the image is displayed correctly on the remote with the direct URL.

I also updated the libraries (minor changes) in requirements