### PR TITLE
Fixed 2 problems : https url images and infinite cycle update of image url

### DIFF
--- a/src/tv.py
+++ b/src/tv.py
@@ -50,7 +50,11 @@ import apps
 import discover
 import inputs
 from config import AtvDevice
-from external_metadata import encode_image_to_data_uri, get_app_metadata
+from external_metadata import (
+    encode_image_to_data_uri,
+    get_app_metadata,
+    reformat_media_image_url,
+)
 from profiles import KeyPress, Profile
 from util import filter_data_img_properties
 
@@ -919,11 +923,8 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
         if status.images and len(status.images) > 0:
             if status.images[0].url != self._media_image_url:
                 self._media_image_url = status.images[0].url
-                # The remote does not support self-signed https URL images, encode https url in case
-                if self._media_image_url.lower().startswith("https"):
-                    update[MediaAttr.MEDIA_IMAGE_URL] = await encode_image_to_data_uri(self._media_image_url)
-                else:
-                    update[MediaAttr.MEDIA_IMAGE_URL] = self._media_image_url
+                # Reformat the media image URL if necessary (image size parameters)
+                update[MediaAttr.MEDIA_IMAGE_URL] = reformat_media_image_url(self._media_image_url)
             self._use_app_url = False
         else:
             self._media_image_url = None


### PR DESCRIPTION
Https url images are not handled on the remote side : so if the media image url starts with "https", it will be converted to binary image data and sent to the remote as a buffer.

Otherwise there was a bug in the existing code : the media_image_url was erased and re-written at each chromecast update. This is resolved now

- Fixes #113
- Closes #79
- Closes #80