### PR TITLE
fix(tv): make the library the single owner of reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 _Changes in the next release_
 
+### Fixed
+- Reconnection is now owned by the androidtvremote2 library alone: the command path no longer spawns competing reconnect tasks.
+- Connected-check is based on the live transport instead of the stale `is_on` attribute.
+- A changed device IP address is rediscovered while reconnecting, so the library can reconnect after a DHCP address change.
+- Background tasks are tracked, cancelled on disconnect and their exceptions are logged instead of being swallowed.
+
 ---
 
 ## v0.9.0 - 2026-07-01

--- a/src/driver.py
+++ b/src/driver.py
@@ -37,6 +37,12 @@ _configured_android_tvs: dict[str, tv.AndroidTv] = {}
 device_profile = DeviceProfile()
 
 
+def _log_task_result(task: asyncio.Task) -> None:
+    """Log the exception of a finished background task, if any."""
+    if not task.cancelled() and task.exception() is not None:
+        _LOG.error("Background task failed: %s", task.exception())
+
+
 @api.listens_to(ucapi.Events.CONNECT)
 async def on_connect():
     """When the UCR2 connects, all configured Android TV devices are getting connected."""
@@ -44,7 +50,8 @@ async def on_connect():
     await api.set_device_state(ucapi.DeviceStates.CONNECTED)  # just to make sure the device state is set
     for atv in _configured_android_tvs.values():
         # start background task
-        _LOOP.create_task(atv.connect())
+        task = _LOOP.create_task(atv.connect())
+        task.add_done_callback(_log_task_result)
 
 
 @api.listens_to(ucapi.Events.DISCONNECT)
@@ -77,7 +84,8 @@ async def on_exit_standby():
     _LOG.debug("Exit standby event: connecting device(s)")
     for configured in _configured_android_tvs.values():
         # start background task
-        _LOOP.create_task(configured.connect())
+        task = _LOOP.create_task(configured.connect())
+        task.add_done_callback(_log_task_result)
 
 
 @api.listens_to(ucapi.Events.SUBSCRIBE_ENTITIES)
@@ -100,7 +108,8 @@ async def on_subscribe_entities(entity_ids) -> None:
             # Even though it's a MediaPlayer state enum, the states are valid for all our entity types
             api.configured_entities.update_attributes(entity_id, {MediaAttr.STATE: state})
 
-            _LOOP.create_task(atv.connect())
+            task = _LOOP.create_task(atv.connect())
+            task.add_done_callback(_log_task_result)
             continue
 
         device = config.devices.get(device_id)
@@ -302,7 +311,8 @@ def _add_configured_android_tv(device_config: config.AtvDevice, connect: bool = 
 
     if connect:
         # start background task
-        _LOOP.create_task(start_connection())
+        task = _LOOP.create_task(start_connection())
+        task.add_done_callback(_log_task_result)
 
     _register_available_entities(device_config, android_tv, profile)
 

--- a/src/tv.py
+++ b/src/tv.py
@@ -233,6 +233,7 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
         self._player_state = media_player.States.ON
         self._muted = False
         self._connect_lock = Lock()
+        self._tasks: set[asyncio.Task] = set()
 
     def __del__(self):
         """Destructs instance, disconnect AndroidTVRemote."""
@@ -460,6 +461,20 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
             _LOG.error("[%s] Initialize pair again. Error: %s", self.log_id, ex)
             return ucapi.StatusCodes.SERVICE_UNAVAILABLE
 
+    def _track(self, coro) -> asyncio.Task:
+        """Create a background task, keep a reference to it and surface its exception if it fails."""
+        task = self._loop.create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        task.add_done_callback(self._log_task_exception)
+        return task
+
+    @staticmethod
+    def _log_task_exception(task: asyncio.Task) -> None:
+        """Log the exception of a finished background task, if any."""
+        if not task.cancelled() and task.exception() is not None:
+            _LOG.error("[androidtv] Background task failed: %s", task.exception())
+
     def _has_live_connection(self) -> bool:
         """Return True only if the underlying transport is actually open."""
         # pylint: disable=protected-access
@@ -645,6 +660,8 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
 
     def disconnect(self) -> None:
         """Disconnect from Android TV."""
+        for task in list(self._tasks):
+            task.cancel()
         self._reconnect_delay = MIN_RECONNECT_DELAY
         self._atv.disconnect()
         if self._chromecast and self._chromecast.socket_client.is_alive():
@@ -744,7 +761,7 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
 
     def _is_on_updated(self, is_on: bool) -> None:
         """Notify that the Android TV power state is updated."""
-        asyncio.create_task(self._handle_is_on_updated(is_on))
+        self._track(self._handle_is_on_updated(is_on))
 
     async def _handle_is_on_updated(self, is_on: bool):
         _LOG.info("[%s] is on: %s", self.log_id, is_on)
@@ -761,7 +778,7 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
 
     def _current_app_updated(self, current_app: str) -> None:
         """Notify that the current app on Android TV is updated."""
-        asyncio.create_task(self._handle_current_app_updated(current_app))
+        self._track(self._handle_current_app_updated(current_app))
 
     async def _handle_current_app_updated(self, current_app: str):
         _LOG.debug("[%s] current_app: %s", self.log_id, current_app)

--- a/src/tv.py
+++ b/src/tv.py
@@ -68,6 +68,9 @@ BACKOFF_MAX: int = 30
 MIN_RECONNECT_DELAY: float = 0.5
 BACKOFF_FACTOR: float = 1.5
 
+RECONNECT_DISCOVERY_DELAY = 30  # seconds before starting IP rediscovery (don't fight fast transient blips)
+RECONNECT_DISCOVERY_INTERVAL = 30  # seconds between IP rediscovery attempts
+
 LONG_PRESS_DELAY: float = 0.8
 
 
@@ -146,6 +149,7 @@ def async_handle_atvlib_errors(
                 raise CannotConnect(f"Device connection not active (state={state})")
 
             # workaround for "swallowed commands" since _atv.send_key_command doesn't provide a result
+            # pylint: disable=protected-access
             if not self._has_live_connection():
                 _LOG.warning(
                     "[%s] Command dropped, remote protocol not active; reconnection is in progress.",
@@ -234,6 +238,7 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
         self._muted = False
         self._connect_lock = Lock()
         self._tasks: set[asyncio.Task] = set()
+        self._ip_rediscovery_task: asyncio.Task | None = None
 
     def __del__(self):
         """Destructs instance, disconnect AndroidTVRemote."""
@@ -658,10 +663,33 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
         else:
             await asyncio.sleep(backoff)
 
+    async def _rediscover_ip_while_disconnected(self) -> None:
+        """While disconnected, periodically look for a changed IP so keep_reconnecting can pick it up."""
+        try:
+            await asyncio.sleep(RECONNECT_DISCOVERY_DELAY)
+            while not self._has_live_connection():
+                for item in await discover.android_tvs():
+                    if item["name"] == self._name and item["address"] != self._atv.host:
+                        _LOG.info(
+                            "[%s] IP address changed: %s -> %s",
+                            self.log_id,
+                            self._atv.host,
+                            item["address"],
+                        )
+                        self._atv.host = item["address"]
+                        self.events.emit(Events.IP_ADDRESS_CHANGED, self._identifier, self._atv.host)
+                        break
+                await asyncio.sleep(RECONNECT_DISCOVERY_INTERVAL)
+        except asyncio.CancelledError:  # pylint: disable=try-except-raise
+            raise
+        except Exception as e:  # pylint: disable=broad-except  # watcher must never kill the task tree
+            _LOG.error("[%s] IP rediscovery failed: %s", self.log_id, e)
+
     def disconnect(self) -> None:
         """Disconnect from Android TV."""
         for task in list(self._tasks):
             task.cancel()
+        self._ip_rediscovery_task = None
         self._reconnect_delay = MIN_RECONNECT_DELAY
         self._atv.disconnect()
         if self._chromecast and self._chromecast.socket_client.is_alive():
@@ -796,7 +824,14 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
         """Notify that the Android TV is ready to receive commands or is unavailable."""
         _LOG.info("[%s] is_available: %s", self.log_id, is_available)
         self._state = DeviceState.CONNECTED if is_available else DeviceState.CONNECTING
-        self.events.emit(Events.CONNECTED if is_available else Events.DISCONNECTED, self.identifier)
+        if is_available:
+            if self._ip_rediscovery_task is not None:
+                self._ip_rediscovery_task.cancel()
+                self._ip_rediscovery_task = None
+        elif self._ip_rediscovery_task is None or self._ip_rediscovery_task.done():
+            # keep_reconnecting() cannot detect a changed IP address on its own: watch for it while disconnected
+            self._ip_rediscovery_task = self._track(self._rediscover_ip_while_disconnected())
+        self.events.emit(Events.CONNECTED if is_available else Events.DISCONNECTED, self._identifier)
 
     def _update_app_list(self) -> None:
         update = {}

--- a/src/tv.py
+++ b/src/tv.py
@@ -146,11 +146,7 @@ def async_handle_atvlib_errors(
                 raise CannotConnect(f"Device connection not active (state={state})")
 
             # workaround for "swallowed commands" since _atv.send_key_command doesn't provide a result
-            # pylint: disable=W0212
-            if (
-                not (self._atv and self._atv._remote_message_protocol and self._atv._remote_message_protocol.transport)
-                or self._atv._remote_message_protocol.transport.is_closing()
-            ):
+            if not self._has_live_connection():
                 _LOG.warning(
                     "[%s] Cannot send command, remote protocol is no longer active. Resetting connection.",
                     self.log_id,
@@ -466,6 +462,12 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
             _LOG.error("[%s] Initialize pair again. Error: %s", self.log_id, ex)
             return ucapi.StatusCodes.SERVICE_UNAVAILABLE
 
+    def _has_live_connection(self) -> bool:
+        """Return True only if the underlying transport is actually open."""
+        # pylint: disable=protected-access
+        proto = self._atv._remote_message_protocol
+        return bool(proto and proto.transport and not proto.transport.is_closing())
+
     # pylint: disable=too-many-statements,too-many-return-statements,too-many-branches
     async def connect(self, max_timeout: int | None = None) -> bool:
         """
@@ -481,7 +483,7 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
 
         await self._connect_lock.acquire()
 
-        if isinstance(self._atv.is_on, bool) and self._atv.is_on:
+        if self._has_live_connection():
             _LOG.debug("[%s] Android TV is already connected", self.log_id)
             # just to make sure the state is up-to-date
             self.events.emit(Events.CONNECTED, self._identifier)

--- a/src/tv.py
+++ b/src/tv.py
@@ -148,18 +148,16 @@ def async_handle_atvlib_errors(
             # workaround for "swallowed commands" since _atv.send_key_command doesn't provide a result
             if not self._has_live_connection():
                 _LOG.warning(
-                    "[%s] Cannot send command, remote protocol is no longer active. Resetting connection.",
+                    "[%s] Command dropped, remote protocol not active; reconnection is in progress.",
                     self.log_id,
                 )
-                self.disconnect()
-                self._loop.create_task(self.connect())
+                # Reconnection is owned by androidtvremote2.keep_reconnecting(); do not spawn a competing connect.
                 return ucapi.StatusCodes.SERVICE_UNAVAILABLE
 
             return await func(self, *args, **kwargs)
         except (CannotConnect, ConnectionClosed) as ex:
-            _LOG.error("[%s] Cannot send command: %s", self.log_id, ex)
-            # pylint: disable=W0212
-            self._loop.create_task(self.connect())
+            _LOG.warning("[%s] Command failed, connection down: %s", self.log_id, ex)
+            # Reconnection is owned by androidtvremote2.keep_reconnecting(); do not spawn a competing connect.
             return ucapi.StatusCodes.SERVICE_UNAVAILABLE
         except InvalidAuth as ex:
             _LOG.error("[%s] Cannot send command: %s", self.log_id, ex)

--- a/src/voice_command.py
+++ b/src/voice_command.py
@@ -51,6 +51,12 @@ _LOG = logging.getLogger(__name__)
 _voice_stream_sessions = defaultdict[VoiceSessionKey, VoiceStream]()
 
 
+def _log_task_result(task: asyncio.Task) -> None:
+    """Log the exception of a finished background task, if any."""
+    if not task.cancelled() and task.exception() is not None:
+        _LOG.error("Background task failed: %s", task.exception())
+
+
 def va_state_from_atv(device: tv.AndroidTv) -> States:
     """Return the voice-assistant state from the given Android TV device."""
     return va_state_from_media_state(device.player_state)
@@ -116,7 +122,8 @@ class VoiceCommand(VoiceAssistant):
             if self._device.is_on is None:
                 return StatusCodes.SERVICE_UNAVAILABLE
             # set up Android TV voice stream as async task to not block the voice_start command
-            asyncio.create_task(self._start_voice(websocket, session_id))
+            task = asyncio.create_task(self._start_voice(websocket, session_id))
+            task.add_done_callback(_log_task_result)
             return StatusCodes.OK
 
         return StatusCodes.BAD_REQUEST


### PR DESCRIPTION
## Summary

Connection-reliability series fixing review findings **P0-3, P0-2, P1-4 and P1-1** of the 2026-07-15 review. Together these make `androidtvremote2.keep_reconnecting()` the **single owner of reconnection** and remove the competing, stale-state-driven reconnect paths that caused dead connections to be reported as connected, duplicate reconnect machinery, silently swallowed task exceptions, and permanent loss of a device after a DHCP address change.

The four commits are ordered and build on each other; they are intended to be reviewed commit by commit.

## Changes

**1. `cbbe5a2` — base connected-check on live transport, not stale `is_on` (P0-3)**
The library's `is_on` attribute is cached and never reset on disconnect, so after a socket drop `connect()` short-circuited with "already connected" on a dead connection. New `_has_live_connection()` checks the actual remote-message transport (protocol exists, transport exists and is not closing) and is now the single definition of "live connection", used by both the `connect()` early-return and the command decorator.

**2. `16b7a32` — delegate reconnection to the library, stop competing reconnects from the command path (P0-2)**
`keep_reconnecting()` already runs a complete reconnect loop with exponential backoff and `is_available` notifications, but the command decorator additionally spawned its own `connect()` tasks (after a `disconnect()` reset on dead transport, and on `CannotConnect`/`ConnectionClosed`) — a second, competing reconnection machinery. The command path now only reports `SERVICE_UNAVAILABLE`; `connect()`'s bounded initial-connect retry loop is kept for the first connect, before `keep_reconnecting()` exists.

**3. `f5135d5` — track background tasks and surface their exceptions (P1-4)**
Fire-and-forget `create_task()` calls kept no reference, no done-callback and no cancellation: exceptions were silently swallowed and tasks could be garbage-collected mid-flight. `tv.py` gets a task registry (`_tasks` + `_track()` helper) that keeps references, logs failures and is cancelled on `disconnect()`; the untracked tasks in `driver.py`/`voice_command.py` get an exception-logging done-callback.

**4. `642ca85` — rediscover changed IP during reconnection (P1-1)**
`keep_reconnecting()` reconnects to the fixed `_atv.host` and cannot detect an IP change; the only rediscovery code lived in the driver's now-inactive retry loop, so a device whose DHCP address changed would never reconnect. A bounded rediscovery watcher runs while disconnected: after a grace delay it periodically discovers Android TVs and updates `_atv.host` (emitting `IP_ADDRESS_CHANGED` to persist the config) so the library's next attempt targets the new address. Started/cancelled from the `is_available` callback, tracked via the task registry. Also fixes `_is_available_updated()` to emit with `_identifier` instead of the `identifier` property, which raises when unset.

## Relation to other work

- Independent of the Google Cast fix in #152 (disjoint subsystem).
- This branch is the declared merge prerequisite for Phase 2 of the connection-lifecycle state machine (`docs/specs/001`), which reuses `_has_live_connection`, `_track` and the rediscovery watcher.

## Verification

- `python -m unittest discover tests` — 41/41 pass
- `black` / `isort` / `flake8` clean, `pylint` 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

