### PR TITLE
feat(tv): drive connection lifecycle through the FSM (spec 001, Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ _Changes in the next release_
 ### Added
 - Pure connection lifecycle state machine `src/connection_fsm.py` with full unit-test coverage
   ([spec 001](docs/specs/001-connection-lifecycle-state-machine.md), Phase 1). Not yet wired into the driver.
+- New internal `RECONNECTING` event, emitted while a lost connection is being re-established
+  ([spec 001](docs/specs/001-connection-lifecycle-state-machine.md), Phase 2). Driver-side wiring follows in Phase 3.
+
+### Changed
+- The runtime connection lifecycle of a device is now driven by the connection state machine
+  ([spec 001](docs/specs/001-connection-lifecycle-state-machine.md), Phase 2):
+  - Short connection losses that recover within a grace period no longer flicker the entities to unavailable.
+  - Authentication errors and unreachable devices are terminal until an explicit user action, with no competing
+    automatic reconnects.
+  - The library reconnect task is supervised: if it dies unexpectedly, the connection is re-established.
+
 ### Fixed
 - Reconnection is now owned by the androidtvremote2 library alone: the command path no longer spawns competing reconnect tasks.
 - Connected-check is based on the live transport instead of the stale `is_on` attribute.

--- a/docs/specs/001-connection-lifecycle-state-machine.md
+++ b/docs/specs/001-connection-lifecycle-state-machine.md
@@ -282,7 +282,18 @@ The table is a module-level `dict[tuple[ConnectionState, Trigger], tuple[Connect
   * `connect()` — on entry `_dispatch(CONNECT_REQUESTED)`; the bounded initial-connect
     loop (kept from Stage 1) dispatches `CONNECT_SUCCEEDED` / `CONNECT_FAILED_AUTH` /
     `CONNECT_ABORTED`. The `START_INITIAL_CONNECT` intent is what launches that loop
-    (guard against re-entry with the existing `_connect_lock`).
+    (guard against re-entry with the existing `_connect_lock`). Two implementation
+    clarifications (Phase 2):
+    * The pre-existing already-connected fast path (live transport and state `CONNECTED`)
+      keeps its safety re-emit of `CONNECTED`, routed through the executor's emit helper
+      so the event and the (already committed) state cannot disagree (INV-3/AC-3).
+    * `connect()` no longer writes `DeviceState.AUTH_ERROR`/`TIMEOUT`/`ERROR` on failure.
+      The setup flow reads `.state` once more *after* `connect(timeout)` (`setup_flow.py:552`),
+      but on current `main` that read was always masked to `DISCONNECTED` by the preceding
+      `disconnect()` call anyway; with Phase 2 the init/pairing `DeviceState` values now
+      survive `disconnect()`, so auth/timeout classification via `init()`/pairing is
+      preserved or improved (AC-11). Connect-phase failures classify as before
+      (CONNECTION_REFUSED).
   * `disconnect()` — `_dispatch(DISCONNECT_REQUESTED)`. The `CANCEL_TASKS` intent
     subsumes the Stage-1 task cancellation; keep the Chromecast teardown as-is.
   * `_is_available_updated(is_available)` — becomes exactly:

--- a/src/tv.py
+++ b/src/tv.py
@@ -14,7 +14,7 @@ import socket
 import time
 from asyncio import AbstractEventLoop, Lock, timeout
 from enum import IntEnum
-from functools import wraps
+from functools import partial, wraps
 from typing import Any, Awaitable, Callable, Concatenate, Coroutine, ParamSpec, TypeVar
 
 import pychromecast
@@ -51,6 +51,13 @@ import apps
 import discover
 import inputs
 from config import AtvDevice
+from connection_fsm import (
+    RECONNECT_GRACE,
+    ConnectionFsm,
+    ConnectionState,
+    Intent,
+    Trigger,
+)
 from external_metadata import (
     encode_icon_to_data_uri,
     get_app_metadata,
@@ -84,6 +91,8 @@ class Events(IntEnum):
     AUTH_ERROR = 4
     UPDATE = 5
     IP_ADDRESS_CHANGED = 6
+    RECONNECTING = 7
+    """Was connected, transport lost, retrying — without marking the entity unavailable (spec 001)."""
 
 
 class DeviceState(IntEnum):
@@ -140,11 +149,14 @@ def async_handle_atvlib_errors(
     async def wrapper(self: _AndroidTvT, *args: _P.args, **kwargs: _P.kwargs) -> ucapi.StatusCodes:
         try:
             # use the same exceptions as the func is throwing (e.g. AndroidTVRemote.send_key_command)
-            state = self.state
-            if state != DeviceState.CONNECTED:
-                if state in (DeviceState.DISCONNECTED, DeviceState.CONNECTING) or self.is_on is None:
+            state = self.connection_state
+            if state != ConnectionState.CONNECTED:
+                if (
+                    state in (ConnectionState.DISCONNECTED, ConnectionState.CONNECTING, ConnectionState.RECONNECTING)
+                    or self.is_on is None
+                ):
                     raise ConnectionClosed("Disconnected from device")
-                if state in (DeviceState.AUTH_ERROR, DeviceState.PAIRING_ERROR):
+                if state == ConnectionState.AUTH_ERROR:
                     raise InvalidAuth("Invalid authentication, device requires to be paired again")
                 raise CannotConnect(f"Device connection not active (state={state})")
 
@@ -239,6 +251,29 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
         self._connect_lock = Lock()
         self._tasks: set[asyncio.Task] = set()
         self._ip_rediscovery_task: asyncio.Task | None = None
+        # Runtime connection lifecycle FSM (spec 001): the single writer of the runtime connection
+        # state (INV-1). Pairing / one-time init state remains on the DeviceState enum.
+        self._conn: ConnectionFsm = ConnectionFsm()
+        self._connect_max_timeout: int | None = None
+        self._initial_connect_task: asyncio.Task[bool] | None = None
+        self._grace_timer_task: asyncio.Task[None] | None = None
+        self._reconnect_auth_failed: bool = False
+        # Intent -> concrete action mapping for the thin async executor (spec 001).
+        self._intent_handlers: dict[Intent, Callable[[], None]] = {
+            Intent.START_INITIAL_CONNECT: self._intent_start_initial_connect,
+            Intent.START_KEEP_RECONNECTING: self._intent_start_keep_reconnecting,
+            Intent.START_CAST: self._intent_start_cast,
+            Intent.START_IP_WATCHER: self._intent_start_ip_watcher,
+            Intent.START_GRACE_TIMER: self._intent_start_grace_timer,
+            Intent.CANCEL_IP_WATCHER: self._intent_cancel_ip_watcher,
+            Intent.CANCEL_GRACE_TIMER: self._intent_cancel_grace_timer,
+            Intent.CANCEL_TASKS: self._intent_cancel_tasks,
+            Intent.ATV_DISCONNECT: self._intent_atv_disconnect,
+            Intent.EMIT_CONNECTED: partial(self._emit_event, Events.CONNECTED),
+            Intent.EMIT_DISCONNECTED: partial(self._emit_event, Events.DISCONNECTED),
+            Intent.EMIT_AUTH_ERROR: partial(self._emit_event, Events.AUTH_ERROR),
+            Intent.EMIT_RECONNECTING: partial(self._emit_event, Events.RECONNECTING),
+        }
 
     def __del__(self):
         """Destructs instance, disconnect AndroidTVRemote."""
@@ -318,8 +353,13 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
 
     @property
     def state(self) -> DeviceState:
-        """Return the device state."""
+        """Return the device state of the one-time init and pairing lifecycles."""
         return self._state
+
+    @property
+    def connection_state(self) -> ConnectionState:
+        """Return the runtime connection state (owned by the connection FSM, spec 001)."""
+        return self._conn.state
 
     @property
     def identifier(self) -> str:
@@ -466,7 +506,7 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
             _LOG.error("[%s] Initialize pair again. Error: %s", self.log_id, ex)
             return ucapi.StatusCodes.SERVICE_UNAVAILABLE
 
-    def _track(self, coro) -> asyncio.Task:
+    def _track(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task:
         """Create a background task, keep a reference to it and surface its exception if it fails."""
         task = self._loop.create_task(coro)
         self._tasks.add(task)
@@ -486,7 +526,125 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
         proto = self._atv._remote_message_protocol
         return bool(proto and proto.transport and not proto.transport.is_closing())
 
-    # pylint: disable=too-many-statements,too-many-return-statements,too-many-branches
+    def _dispatch(self, trigger: Trigger) -> None:
+        """Drive the connection FSM with a trigger and execute the returned intents.
+
+        This is the only place ``ConnectionFsm.apply()`` is called (INV-1) and — via
+        :meth:`_execute` — the only place connection events are emitted (INV-3).
+        Intents run after the state transition is committed by ``apply()``.
+        """
+        for intent in self._conn.apply(trigger):
+            self._execute(intent)
+
+    def _execute(self, intent: Intent) -> None:
+        """Perform a single FSM intent.
+
+        Defensive per spec F8: a failing emit or task-start is logged and must not corrupt
+        the connection state, which is already committed by ``apply()`` before intents run.
+        """
+        try:
+            self._intent_handlers[intent]()
+        except Exception as ex:
+            _LOG.error("[%s] Failed to execute intent %s: %s", self.log_id, intent.name, ex)
+
+    def _emit_event(self, event: Events) -> None:
+        """Emit a connection event. Only called by the FSM intent executor (INV-3)."""
+        self.events.emit(event, self._identifier)
+
+    def _intent_start_initial_connect(self) -> None:
+        """Spawn the bounded initial-connect coroutine."""
+        # consume-once max_timeout: only an explicit connect(max_timeout=...) call bounds the
+        # retry loop; an FSM-internal restart (e.g. reconnect-owner supervision) retries unbounded.
+        max_timeout = self._connect_max_timeout
+        self._connect_max_timeout = None
+        self._initial_connect_task = self._track(self._initial_connect(max_timeout))
+
+    def _intent_start_keep_reconnecting(self) -> None:
+        """Hand over reconnection ownership to the library and supervise the owner task."""
+        self._reconnect_auth_failed = False
+        self._atv.keep_reconnecting(self._handle_invalid_auth)
+        # Supervise the single reconnect owner (spec F11): if the library task dies silently,
+        # re-establish ownership. Accessing the private _reconnect_task attribute is accepted and
+        # pinned to androidtvremote2==0.3.1 (spec Decision 5); re-verify on any library bump.
+        # pylint: disable=protected-access
+        reconnect_task = self._atv._reconnect_task
+        if reconnect_task is None:
+            _LOG.warning("[%s] Cannot supervise reconnect owner: no reconnect task", self.log_id)
+            return
+        reconnect_task.add_done_callback(self._on_reconnect_owner_done)
+
+    def _intent_start_cast(self) -> None:
+        """(Re-)establish the Google Cast connection in a background task."""
+        self._track(self._chromecast_connect())
+
+    def _intent_start_ip_watcher(self) -> None:
+        """Start the Stage-1 IP-rediscovery watcher if it is not already running."""
+        if self._ip_rediscovery_task is None or self._ip_rediscovery_task.done():
+            # keep_reconnecting() cannot detect a changed IP address on its own: watch for it while disconnected
+            self._ip_rediscovery_task = self._track(self._rediscover_ip_while_disconnected())
+
+    def _intent_start_grace_timer(self) -> None:
+        """Arm the reconnect grace timer (INV-5)."""
+        self._grace_timer_task = self._track(self._reconnect_grace_timer())
+
+    def _intent_cancel_ip_watcher(self) -> None:
+        """Cancel the IP-rediscovery watcher task."""
+        if self._ip_rediscovery_task is not None:
+            self._ip_rediscovery_task.cancel()
+            self._ip_rediscovery_task = None
+
+    def _intent_cancel_grace_timer(self) -> None:
+        """Cancel the reconnect grace timer task."""
+        if self._grace_timer_task is not None:
+            self._grace_timer_task.cancel()
+            self._grace_timer_task = None
+
+    def _intent_cancel_tasks(self) -> None:
+        """Cancel all tracked background tasks the device owns (INV-7)."""
+        for task in list(self._tasks):
+            task.cancel()
+        self._ip_rediscovery_task = None
+        self._grace_timer_task = None
+        self._initial_connect_task = None
+
+    def _intent_atv_disconnect(self) -> None:
+        """Disconnect the androidtvremote2 library (also cancels its reconnect task)."""
+        self._atv.disconnect()
+
+    async def _reconnect_grace_timer(self) -> None:
+        """Dispatch GRACE_ELAPSED if the transport stays lost beyond RECONNECT_GRACE (INV-5)."""
+        # RECONNECT_GRACE is provisional, see comment in connection_fsm.py (spec Decision 4)
+        await asyncio.sleep(RECONNECT_GRACE)
+        self._dispatch(Trigger.GRACE_ELAPSED)
+
+    def _handle_invalid_auth(self) -> None:
+        """Handle the invalid-authentication callback from keep_reconnecting()."""
+        self._reconnect_auth_failed = True
+        _LOG.error(
+            "[%s] Invalid authentication for %s while reconnecting",
+            self.log_id,
+            self._identifier,
+        )
+        self._dispatch(Trigger.RECONNECT_AUTH_FAILED)
+
+    def _on_reconnect_owner_done(self, task: asyncio.Task) -> None:
+        """Supervise the library reconnect owner (spec F11).
+
+        If the keep_reconnecting() task terminates without cancellation and without the
+        invalid-auth callback having fired, it died silently on an unexpected exception:
+        log an error and re-establish ownership through the existing transition table.
+        """
+        if task.cancelled() or self._reconnect_auth_failed:
+            return
+        exception = task.exception()
+        _LOG.error(
+            "[%s] Reconnect owner terminated unexpectedly (%s), re-establishing ownership",
+            self.log_id,
+            exception if exception is not None else "no exception",
+        )
+        self._dispatch(Trigger.DISCONNECT_REQUESTED)
+        self._dispatch(Trigger.CONNECT_REQUESTED)
+
     async def connect(self, max_timeout: int | None = None) -> bool:
         """
         Connect to Android TV.
@@ -499,95 +657,100 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
             _LOG.debug("[%s] Connection task already running", self.log_id)
             return True
 
-        await self._connect_lock.acquire()
-
-        if self._has_live_connection():
+        if self._has_live_connection() and self._conn.state == ConnectionState.CONNECTED:
             _LOG.debug("[%s] Android TV is already connected", self.log_id)
-            # just to make sure the state is up-to-date
-            self.events.emit(Events.CONNECTED, self._identifier)
-            self._connect_lock.release()
+            # just to make sure the client state is up-to-date; the FSM state is already
+            # CONNECTED, so the emitted event and the state agree (INV-3)
+            self._execute(Intent.EMIT_CONNECTED)
             return True
 
-        self._state = DeviceState.CONNECTING
-        # disconnect first for a clean state if the connection is in limbo
-        self._atv.disconnect()
+        self._connect_max_timeout = max_timeout
+        self._initial_connect_task = None
+        self._dispatch(Trigger.CONNECT_REQUESTED)
 
-        request_start = None
-        success = False
-        start = time.time()
+        initial_connect_task = self._initial_connect_task
+        if initial_connect_task is None:
+            # no-op transition: initial connect already running or library reconnect in progress
+            _LOG.debug(
+                "[%s] Connect request ignored in state %s: connection attempt already in progress",
+                self.log_id,
+                self._conn.state.name,
+            )
+            return True
 
-        while not success:
-            try:
-                _LOG.debug(
-                    "[%s] Connecting Android TV %s on %s (timeout=%.1fs)",
-                    self.log_id,
-                    self._identifier,
-                    self._atv.host,
-                    CONNECTION_TIMEOUT,
-                )
-                self.events.emit(Events.CONNECTING, self._identifier)
-                request_start = time.time()
-                async with timeout(CONNECTION_TIMEOUT):
-                    await self._atv.async_connect()
-                success = True
-                self._connection_attempts = 0
-                self._reconnect_delay = MIN_RECONNECT_DELAY
-            except InvalidAuth:
-                self._state = DeviceState.AUTH_ERROR
-                _LOG.error("[%s] Invalid authentication for %s", self.log_id, self._identifier)
-                self.events.emit(Events.AUTH_ERROR, self._identifier)
-                break
-            except (CannotConnect, ConnectionClosed, asyncio.TimeoutError) as ex:
-                if max_timeout and time.time() - start > max_timeout:
-                    self._state = DeviceState.TIMEOUT
-                    _LOG.error(
-                        "[%s] Abort connecting after %ds: device %s not reachable on %s. %s",
+        try:
+            return await initial_connect_task
+        except asyncio.CancelledError:
+            # initial connect was aborted by disconnect() (spec F5)
+            return False
+
+    async def _initial_connect(self, max_timeout: int | None) -> bool:
+        """Bounded initial-connect loop, started by the START_INITIAL_CONNECT intent.
+
+        Dispatches CONNECT_SUCCEEDED / CONNECT_FAILED_AUTH / CONNECT_ABORTED. Cancellation
+        (disconnect() while connecting) propagates without dispatching success (spec F5).
+
+        :param max_timeout: optional maximum time in seconds to try connecting. Default: no timeout.
+        :return: True if connected, False if timeout or authentication error occurred.
+        """
+        async with self._connect_lock:
+            # disconnect first for a clean state if the connection is in limbo
+            self._atv.disconnect()
+
+            request_start = None
+            start = time.time()
+
+            while True:
+                try:
+                    _LOG.debug(
+                        "[%s] Connecting Android TV %s on %s (timeout=%.1fs)",
                         self.log_id,
-                        max_timeout,
+                        self._identifier,
+                        self._atv.host,
+                        CONNECTION_TIMEOUT,
+                    )
+                    self.events.emit(Events.CONNECTING, self._identifier)
+                    request_start = time.time()
+                    async with timeout(CONNECTION_TIMEOUT):
+                        await self._atv.async_connect()
+                    break
+                except InvalidAuth:
+                    _LOG.error("[%s] Invalid authentication for %s", self.log_id, self._identifier)
+                    self._dispatch(Trigger.CONNECT_FAILED_AUTH)
+                    return False
+                except (CannotConnect, ConnectionClosed, asyncio.TimeoutError) as ex:
+                    if max_timeout and time.time() - start > max_timeout:
+                        _LOG.error(
+                            "[%s] Abort connecting after %ds: device %s not reachable on %s. %s",
+                            self.log_id,
+                            max_timeout,
+                            self._identifier,
+                            self._atv.host,
+                            ex,
+                        )
+                        self._dispatch(Trigger.CONNECT_ABORTED)
+                        return False
+                    await self._handle_connection_failure(time.time() - request_start, ex)
+                except Exception as ex:
+                    _LOG.error(
+                        "[%s] Fatal error connecting Android TV %s on %s: %s",
+                        self.log_id,
                         self._identifier,
                         self._atv.host,
                         ex,
                     )
-                    break
-                await self._handle_connection_failure(time.time() - request_start, ex)
-            except Exception as ex:
-                self._state = DeviceState.ERROR
-                _LOG.error(
-                    "[%s] Fatal error connecting Android TV %s on %s: %s",
-                    self.log_id,
-                    self._identifier,
-                    self._atv.host,
-                    ex,
-                )
-                break
+                    self._dispatch(Trigger.CONNECT_ABORTED)
+                    return False
 
-        self._connect_lock.release()
-        if not success:
-            if self._state == DeviceState.CONNECTING:
-                self._state = DeviceState.ERROR
-            return False
+            self._connection_attempts = 0
+            self._reconnect_delay = MIN_RECONNECT_DELAY
 
-        def _handle_invalid_auth() -> None:
-            self._state = DeviceState.AUTH_ERROR
-            _LOG.error(
-                "[%s] Invalid authentication for %s while reconnecting",
-                self.log_id,
-                self._identifier,
-            )
-            self.events.emit(Events.AUTH_ERROR, self._identifier)
+            _LOG.info("[%s] Device information: %s", self.log_id, self._atv.device_info)
+            self._update_app_list()
 
-        self._atv.keep_reconnecting(_handle_invalid_auth)
-
-        device_info = self._atv.device_info
-        _LOG.info("[%s] Device information: %s", self.log_id, device_info)
-
-        self._update_app_list()
-        self._state = DeviceState.CONNECTED
-        self.events.emit(Events.CONNECTED, self._identifier)
-
-        # Connect to Chromecast if supported
-        await self._chromecast_connect()
-        return True
+            # commits CONNECTED and performs START_KEEP_RECONNECTING, START_CAST, EMIT_CONNECTED
+            self._dispatch(Trigger.CONNECT_SUCCEEDED)
+            return True
 
     async def _chromecast_connect(self) -> None:
         if not self._device_config.use_chromecast:
@@ -698,20 +861,18 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
 
     def disconnect(self) -> None:
         """Disconnect from Android TV."""
-        for task in list(self._tasks):
-            task.cancel()
-        self._ip_rediscovery_task = None
         self._reconnect_delay = MIN_RECONNECT_DELAY
-        self._atv.disconnect()
+        # performs CANCEL_TASKS (INV-7), ATV_DISCONNECT and EMIT_DISCONNECTED; no-op if already disconnected
+        self._dispatch(Trigger.DISCONNECT_REQUESTED)
+        # Google Cast teardown is kept outside the FSM (out of scope for spec 001)
         if self._chromecast and self._chromecast.socket_client.is_alive():
             try:
                 self._chromecast.disconnect(timeout=0)
             except Exception:
                 pass
-        self._state = DeviceState.DISCONNECTED
-        self.events.emit(Events.DISCONNECTED, self._identifier)
 
     # Callbacks
+    # pylint: disable-next=too-many-branches,too-many-statements
     async def _apply_current_app_metadata(self, current_app: str) -> dict:
         update = {}
 
@@ -831,18 +992,10 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
         update = {MediaAttr.VOLUME: volume_info["level"], MediaAttr.MUTED: self._muted}
         self.events.emit(Events.UPDATE, self._identifier, update)
 
-    def _is_available_updated(self, is_available: bool):
+    def _is_available_updated(self, is_available: bool) -> None:
         """Notify that the Android TV is ready to receive commands or is unavailable."""
         _LOG.info("[%s] is_available: %s", self.log_id, is_available)
-        self._state = DeviceState.CONNECTED if is_available else DeviceState.CONNECTING
-        if is_available:
-            if self._ip_rediscovery_task is not None:
-                self._ip_rediscovery_task.cancel()
-                self._ip_rediscovery_task = None
-        elif self._ip_rediscovery_task is None or self._ip_rediscovery_task.done():
-            # keep_reconnecting() cannot detect a changed IP address on its own: watch for it while disconnected
-            self._ip_rediscovery_task = self._track(self._rediscover_ip_while_disconnected())
-        self.events.emit(Events.CONNECTED if is_available else Events.DISCONNECTED, self._identifier)
+        self._dispatch(Trigger.TRANSPORT_AVAILABLE if is_available else Trigger.TRANSPORT_LOST)
 
     def _update_app_list(self) -> None:
         update = {}
@@ -983,6 +1136,7 @@ class AndroidTv(CastStatusListener, MediaStatusListener, ConnectionStatusListene
         except Exception as e:
             _LOG.error("[%s] Failed to schedule media status handler: %s", self.log_id, e)
 
+    # pylint: disable-next=too-many-branches,too-many-statements
     async def _handle_new_media_status(self, status: MediaStatus):
         update = {}
 

--- a/tests/test_tv_connection.py
+++ b/tests/test_tv_connection.py
@@ -1,0 +1,561 @@
+"""
+Integration tests for the AndroidTv connection lifecycle FSM executor (spec 001, Phase 2).
+
+Drives ``AndroidTv`` with a fake ``AndroidTVRemote`` per the spec's Test Plan section
+"tests/test_tv_connection.py". No network, no real sleeps: grace-timer behaviour is
+tested by dispatching ``GRACE_ELAPSED`` directly, and the bounded initial-connect
+timeout is tested with a fake clock.
+
+:copyright: (c) 2026 by Unfolded Circle ApS.
+:license: Mozilla Public License Version 2.0, see LICENSE for more details.
+"""
+
+import ast
+import asyncio
+import sys
+import unittest
+from functools import partial
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import patch
+
+_SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+if str(_SRC_DIR) not in sys.path:
+    # tv.py uses top-level imports (apps, config, ...), so import it the same way the driver does
+    sys.path.insert(0, str(_SRC_DIR))
+
+# pylint: disable=wrong-import-position
+import ucapi  # noqa: E402
+from androidtvremote2 import CannotConnect, InvalidAuth  # noqa: E402
+
+import tv  # noqa: E402
+from config import AtvDevice  # noqa: E402
+from connection_fsm import ConnectionState, Trigger  # noqa: E402
+from tv import AndroidTv, Events  # noqa: E402
+
+
+class _FakeTransport:
+    """Transport stub with a controllable is_closing() result."""
+
+    def __init__(self) -> None:
+        self.closing: bool = False
+
+    def is_closing(self) -> bool:
+        return self.closing
+
+
+class _FakeRemoteProtocol:
+    """Remote message protocol stub exposing a fake transport."""
+
+    def __init__(self) -> None:
+        self.transport = _FakeTransport()
+
+
+class FakeAndroidTVRemote:
+    """Fake androidtvremote2.AndroidTVRemote — no network, fully controllable."""
+
+    # pylint: disable=too-many-instance-attributes,unused-argument
+    def __init__(
+        self,
+        client_name: str = "",
+        certfile: str = "",
+        keyfile: str = "",
+        host: str = "",
+        loop: asyncio.AbstractEventLoop | None = None,
+        enable_voice: bool = True,
+    ) -> None:
+        self.host = host
+        self.is_on: bool | None = None
+        self.current_app: str | None = None
+        self.device_info: dict[str, str] = {"manufacturer": "Fake", "model": "TV"}
+        self.is_voice_enabled: bool | None = None
+        self._loop = loop or asyncio.get_event_loop()
+
+        self.connect_error: Exception | None = None
+        """Exception raised by async_connect() if set (InvalidAuth / CannotConnect)."""
+        self.connect_gate: asyncio.Event | None = None
+        """If set, async_connect() blocks until the event is set (to test disconnect while connecting)."""
+
+        self.async_connect_calls: int = 0
+        self.disconnect_calls: int = 0
+        self.keep_reconnecting_calls: int = 0
+        self.invalid_auth_callback: Callable[[], None] | None = None
+        self.is_on_updated_cb: Callable[[bool], None] | None = None
+        self.current_app_updated_cb: Callable[[str], None] | None = None
+        self.volume_info_updated_cb: Callable[[dict], None] | None = None
+        self.is_available_updated_cb: Callable[[bool], None] | None = None
+
+        self._remote_message_protocol: _FakeRemoteProtocol | None = None
+        self._reconnect_task: asyncio.Task | None = None
+        self._reconnect_result: asyncio.Future | None = None
+
+    # callback registrars
+
+    def add_is_on_updated_callback(self, callback: Callable[[bool], None]) -> None:
+        self.is_on_updated_cb = callback
+
+    def add_current_app_updated_callback(self, callback: Callable[[str], None]) -> None:
+        self.current_app_updated_cb = callback
+
+    def add_volume_info_updated_callback(self, callback: Callable[[dict], None]) -> None:
+        self.volume_info_updated_cb = callback
+
+    def add_is_available_updated_callback(self, callback: Callable[[bool], None]) -> None:
+        self.is_available_updated_cb = callback
+
+    # connection API
+
+    async def async_connect(self) -> None:
+        self.async_connect_calls += 1
+        if self.connect_gate is not None:
+            await self.connect_gate.wait()
+        if self.connect_error is not None:
+            raise self.connect_error
+        self._remote_message_protocol = _FakeRemoteProtocol()
+        self.is_on = True
+
+    def keep_reconnecting(self, invalid_auth_callback: Callable[[], None] | None = None) -> None:
+        self.keep_reconnecting_calls += 1
+        self.invalid_auth_callback = invalid_auth_callback
+        self._reconnect_result = self._loop.create_future()
+        self._reconnect_task = self._loop.create_task(self._reconnect_owner())
+
+    async def _reconnect_owner(self) -> None:
+        assert self._reconnect_result is not None
+        await self._reconnect_result
+
+    def fail_reconnect_owner(self, exception: Exception) -> None:
+        """Terminate the reconnect owner task with an exception (spec F11)."""
+        assert self._reconnect_result is not None
+        self._reconnect_result.set_exception(exception)
+
+    def finish_reconnect_owner(self) -> None:
+        """Terminate the reconnect owner task without exception (library exit on invalid auth)."""
+        assert self._reconnect_result is not None
+        self._reconnect_result.set_result(None)
+
+    def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        # mirrors androidtvremote2 0.3.1: disconnect() cancels the reconnect task and drops the protocol
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+        self._remote_message_protocol = None
+
+    # test helpers
+
+    def make_transport_live(self) -> None:
+        self._remote_message_protocol = _FakeRemoteProtocol()
+
+    def drop_transport(self) -> None:
+        self._remote_message_protocol = None
+
+
+class _FakeTime:
+    """time-module stand-in: every time() call advances the clock by 100 s (no real sleeps)."""
+
+    def __init__(self) -> None:
+        self.now: float = 0.0
+
+    def time(self) -> float:
+        self.now += 100.0
+        return self.now
+
+
+class TvConnectionTestCase(unittest.IsolatedAsyncioTestCase):
+    """Base fixture: an AndroidTv wired to a FakeAndroidTVRemote, with event capture."""
+
+    # pylint: disable=protected-access
+
+    async def asyncSetUp(self) -> None:
+        self.loop = asyncio.get_running_loop()
+        for patcher in (
+            patch.object(tv, "AndroidTVRemote", FakeAndroidTVRemote),
+            # keep the (real) grace timer far in the future; grace tests dispatch GRACE_ELAPSED directly
+            patch.object(tv, "RECONNECT_GRACE", 60.0),
+        ):
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        device = AtvDevice(id="fake1", name="Fake TV", address="10.0.0.2")
+        self.atv = AndroidTv("cert.pem", "key.pem", device, profile=None, loop=self.loop)
+        self.fake: FakeAndroidTVRemote = self.atv._atv  # type: ignore[assignment]
+        self.events: dict[Events, int] = {event: 0 for event in Events}
+        for event in Events:
+            self.atv.events.on(event, partial(self._record_event, event))
+
+    async def asyncTearDown(self) -> None:
+        self.atv.events.remove_all_listeners()
+        self.atv.disconnect()
+        await self._drain()
+
+    def _record_event(self, event: Events, *_args: Any) -> None:
+        self.events[event] += 1
+
+    async def _drain(self, rounds: int = 10) -> None:
+        """Give scheduled callbacks and cancellations a chance to run (no real sleeps)."""
+        for _ in range(rounds):
+            await asyncio.sleep(0)
+
+    async def _wait_for(self, predicate: Callable[[], bool], timeout: float = 2.0) -> None:
+        """Yield to the loop until the predicate holds; fail after the wall-clock timeout."""
+        deadline = self.loop.time() + timeout
+        while not predicate():
+            if self.loop.time() > deadline:
+                self.fail("condition not met in time")
+            await asyncio.sleep(0)
+
+    def _drop_transport_and_notify(self) -> None:
+        """Simulate a transport loss: drop the protocol and fire the library is_available(False) callback."""
+        self.fake.drop_transport()
+        assert self.fake.is_available_updated_cb is not None
+        self.fake.is_available_updated_cb(False)
+
+    def _restore_transport_and_notify(self) -> None:
+        """Simulate library reconnection: restore the protocol and fire is_available(True)."""
+        self.fake.make_transport_live()
+        assert self.fake.is_available_updated_cb is not None
+        self.fake.is_available_updated_cb(True)
+
+
+class InitialConnectTest(TvConnectionTestCase):
+    """Test-Plan items 1 and 2 plus the initial-connect failure paths."""
+
+    async def test_initial_success(self):
+        """Item 1: keep_reconnecting once, CONNECTED emitted once, state CONNECTED (INV-2/INV-3)."""
+        result = await self.atv.connect()
+
+        self.assertTrue(result)
+        self.assertEqual(self.fake.keep_reconnecting_calls, 1)
+        self.assertEqual(self.events[Events.CONNECTED], 1)
+        self.assertEqual(self.events[Events.DISCONNECTED], 0)
+        self.assertEqual(self.atv.connection_state, ConnectionState.CONNECTED)
+
+    async def test_stale_is_on_with_closed_transport_reconnects(self):
+        """Item 2 (P0-3): is_on=True with a closing transport must not short-circuit connect() (INV-4)."""
+        self.fake.is_on = True
+        self.fake.make_transport_live()
+        assert self.fake._remote_message_protocol is not None
+        self.fake._remote_message_protocol.transport.closing = True
+        self.assertFalse(self.atv._has_live_connection())
+
+        result = await self.atv.connect()
+
+        self.assertTrue(result)
+        self.assertEqual(self.fake.async_connect_calls, 1, "connect() must proceed instead of short-circuiting")
+        self.assertEqual(self.atv.connection_state, ConnectionState.CONNECTED)
+
+    async def test_connect_while_connected_is_idempotent(self):
+        """connect() with a live connection re-emits CONNECTED but starts nothing new."""
+        await self.atv.connect()
+
+        result = await self.atv.connect()
+
+        self.assertTrue(result)
+        self.assertEqual(self.fake.async_connect_calls, 1)
+        self.assertEqual(self.fake.keep_reconnecting_calls, 1)
+        self.assertEqual(self.events[Events.CONNECTED], 2)
+        self.assertEqual(self.atv.connection_state, ConnectionState.CONNECTED)
+
+    async def test_initial_connect_invalid_auth(self):
+        """InvalidAuth during initial connect: AUTH_ERROR state and event, no reconnect (INV-6)."""
+        self.fake.connect_error = InvalidAuth("bad cert")
+
+        result = await self.atv.connect()
+
+        self.assertFalse(result)
+        self.assertEqual(self.atv.connection_state, ConnectionState.AUTH_ERROR)
+        self.assertEqual(self.events[Events.AUTH_ERROR], 1)
+        self.assertEqual(self.fake.keep_reconnecting_calls, 0)
+
+    async def test_initial_connect_aborted_after_max_timeout(self):
+        """CannotConnect past max_timeout: UNREACHABLE state, exactly one DISCONNECTED (INV-6)."""
+        self.fake.connect_error = CannotConnect("nope")
+
+        with patch.object(tv, "time", _FakeTime()):  # fake clock: abort check trips without real sleeps
+            result = await self.atv.connect(max_timeout=1)
+
+        self.assertFalse(result)
+        self.assertEqual(self.atv.connection_state, ConnectionState.UNREACHABLE)
+        self.assertEqual(self.events[Events.DISCONNECTED], 1)
+        self.assertEqual(self.fake.keep_reconnecting_calls, 0)
+
+
+class CommandPathTest(TvConnectionTestCase):
+    """Test-Plan item 3 (P0-2 regression)."""
+
+    async def test_command_while_reconnecting_returns_service_unavailable(self):
+        """A command while RECONNECTING must not spawn a connect nor cancel the library reconnect (INV-2)."""
+        await self.atv.connect()
+        connects_before = self.fake.async_connect_calls
+
+        self._drop_transport_and_notify()
+        self.assertEqual(self.atv.connection_state, ConnectionState.RECONNECTING)
+
+        result = await self.atv._send_command("POWER")
+
+        self.assertEqual(result, ucapi.StatusCodes.SERVICE_UNAVAILABLE)
+        self.assertEqual(self.fake.async_connect_calls, connects_before, "no second connect may be spawned")
+        assert self.fake._reconnect_task is not None
+        self.assertFalse(self.fake._reconnect_task.done(), "library reconnect must keep running")
+        self.assertEqual(self.fake._reconnect_task.cancelling(), 0, "library reconnect must not be cancelled")
+        self.assertEqual(self.fake.keep_reconnecting_calls, 1)
+
+
+class IpRediscoveryTest(TvConnectionTestCase):
+    """Test-Plan item 4 (P1-1)."""
+
+    async def test_changed_ip_is_discovered_while_reconnecting(self):
+        """While RECONNECTING, a changed discovered IP updates _atv.host and emits IP_ADDRESS_CHANGED."""
+        await self.atv.connect()
+
+        async def _fake_discover() -> list[dict[str, str]]:
+            # revive the transport so the watcher loop exits after applying the new address
+            self.fake.make_transport_live()
+            return [{"name": "Fake TV", "address": "10.0.0.99"}]
+
+        with (
+            patch.object(tv, "RECONNECT_DISCOVERY_DELAY", 0),
+            patch.object(tv, "RECONNECT_DISCOVERY_INTERVAL", 0),
+            patch.object(tv.discover, "android_tvs", _fake_discover),
+        ):
+            self._drop_transport_and_notify()
+            watcher = self.atv._ip_rediscovery_task
+            self.assertIsNotNone(watcher, "TRANSPORT_LOST must start the IP watcher")
+            await asyncio.wait_for(watcher, 2)
+
+        self.assertEqual(self.fake.host, "10.0.0.99")
+        self.assertEqual(self.events[Events.IP_ADDRESS_CHANGED], 1)
+
+
+class FlickerSuppressionTest(TvConnectionTestCase):
+    """Test-Plan item 5 (INV-5), end-to-end. GRACE_ELAPSED is dispatched directly (no real sleeps)."""
+
+    async def test_recovery_within_grace_emits_no_disconnected(self):
+        await self.atv.connect()
+
+        self._drop_transport_and_notify()
+        self.assertEqual(self.atv.connection_state, ConnectionState.RECONNECTING)
+        self.assertEqual(self.events[Events.RECONNECTING], 1)
+        self.assertEqual(self.events[Events.DISCONNECTED], 0)
+
+        self._restore_transport_and_notify()
+        self.assertEqual(self.atv.connection_state, ConnectionState.CONNECTED)
+        self.assertEqual(self.events[Events.DISCONNECTED], 0, "no DISCONNECTED flicker within grace (INV-5)")
+        self.assertEqual(self.events[Events.CONNECTED], 2)
+
+    async def test_exceeding_grace_emits_exactly_one_disconnected(self):
+        await self.atv.connect()
+
+        self._drop_transport_and_notify()
+        self.atv._dispatch(Trigger.GRACE_ELAPSED)
+
+        self.assertEqual(self.atv.connection_state, ConnectionState.RECONNECTING)
+        self.assertEqual(self.events[Events.DISCONNECTED], 1)
+
+        # late recovery still emits CONNECTED and no further DISCONNECTED
+        self._restore_transport_and_notify()
+        self.assertEqual(self.atv.connection_state, ConnectionState.CONNECTED)
+        self.assertEqual(self.events[Events.DISCONNECTED], 1)
+
+
+class TeardownTest(TvConnectionTestCase):
+    """Test-Plan item 6 (INV-7): disconnect() cancels every owned task and lands in DISCONNECTED."""
+
+    async def test_disconnect_while_connecting(self):
+        self.fake.connect_gate = asyncio.Event()  # async_connect() hangs
+        connect_task = self.loop.create_task(self.atv.connect())
+        await self._wait_for(lambda: self.fake.async_connect_calls == 1)
+        self.assertEqual(self.atv.connection_state, ConnectionState.CONNECTING)
+        tracked = list(self.atv._tasks)
+        self.assertTrue(tracked)
+
+        self.atv.disconnect()
+
+        self.assertEqual(self.atv.connection_state, ConnectionState.DISCONNECTED)
+        self.assertFalse(await connect_task, "aborted connect() must return False")
+        await self._drain()
+        self.assertFalse(self.atv._tasks, "no tracked task may survive disconnect()")
+        for task in tracked:
+            self.assertTrue(task.cancelled())
+        self.assertEqual(self.events[Events.DISCONNECTED], 1)
+        self.assertEqual(self.events[Events.CONNECTED], 0, "cancelled initial connect must not dispatch success")
+
+    async def test_disconnect_while_connected(self):
+        await self.atv.connect()
+
+        self.atv.disconnect()
+
+        self.assertEqual(self.atv.connection_state, ConnectionState.DISCONNECTED)
+        self.assertGreaterEqual(self.fake.disconnect_calls, 1)
+        await self._drain()
+        assert self.fake._reconnect_task is not None
+        self.assertTrue(self.fake._reconnect_task.cancelled(), "library reconnect owner must be stopped")
+        self.assertFalse(self.atv._tasks)
+        self.assertEqual(self.events[Events.DISCONNECTED], 1)
+
+    async def test_disconnect_while_reconnecting(self):
+        await self.atv.connect()
+        self._drop_transport_and_notify()
+        watcher = self.atv._ip_rediscovery_task
+        grace = self.atv._grace_timer_task
+        self.assertIsNotNone(watcher)
+        self.assertIsNotNone(grace)
+
+        self.atv.disconnect()
+
+        self.assertEqual(self.atv.connection_state, ConnectionState.DISCONNECTED)
+        await self._drain()
+        self.assertTrue(watcher.cancelled())
+        self.assertTrue(grace.cancelled())
+        self.assertIsNone(self.atv._ip_rediscovery_task)
+        self.assertIsNone(self.atv._grace_timer_task)
+        self.assertFalse(self.atv._tasks)
+
+
+class AuthTerminalTest(TvConnectionTestCase):
+    """Test-Plan item 7 (INV-6)."""
+
+    async def test_reconnect_auth_failure_is_terminal(self):
+        await self.atv.connect()
+        self._drop_transport_and_notify()
+        watcher = self.atv._ip_rediscovery_task
+        grace = self.atv._grace_timer_task
+
+        assert self.fake.invalid_auth_callback is not None
+        self.fake.invalid_auth_callback()
+        # the library reconnect owner exits without exception after invalid auth
+        self.fake.finish_reconnect_owner()
+        await self._drain()
+
+        self.assertEqual(self.atv.connection_state, ConnectionState.AUTH_ERROR)
+        self.assertEqual(self.events[Events.AUTH_ERROR], 1)
+        self.assertTrue(watcher.cancelled(), "IP watcher must be cancelled on AUTH_ERROR")
+        self.assertTrue(grace.cancelled(), "grace timer must be cancelled on AUTH_ERROR")
+        self.assertEqual(self.fake.keep_reconnecting_calls, 1, "no automatic reconnect from AUTH_ERROR")
+        self.assertEqual(self.fake.async_connect_calls, 1)
+
+        # terminal: transport events do not leave AUTH_ERROR
+        self._restore_transport_and_notify()
+        self.assertEqual(self.atv.connection_state, ConnectionState.AUTH_ERROR)
+
+
+class SingleWriterAuditTest(unittest.TestCase):
+    """Test-Plan item 8 (INV-1): runtime connection state is written only by ConnectionFsm.apply().
+
+    Phase 1 named the FSM state attribute ``self._state`` (inside connection_fsm.py); the
+    spec's literal grep target ``self._conn_state`` is asserted as well. In tv.py the same
+    attribute name is legitimately used for the out-of-scope init/pairing DeviceState, so the
+    audit verifies that every ``self._state`` write in tv.py assigns a DeviceState member from
+    an allowed init/pairing method, and that the FSM instance itself is never written to.
+    """
+
+    _ALLOWED_DEVICE_STATE_WRITERS = {"__init__", "init", "start_pairing", "finish_pairing"}
+
+    @staticmethod
+    def _attribute_writes(tree: ast.Module) -> list[tuple[str, ast.Attribute, ast.AST]]:
+        """Return (enclosing_function, target_attribute, value) for all self.* attribute assignments."""
+        writes: list[tuple[str, ast.Attribute, ast.AST]] = []
+
+        def visit(node: ast.AST, func: str) -> None:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                func = node.name
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Attribute):
+                        writes.append((func, target, node.value))
+            elif isinstance(node, (ast.AnnAssign, ast.AugAssign)) and isinstance(node.target, ast.Attribute):
+                writes.append((func, node.target, node.value))
+            for child in ast.iter_child_nodes(node):
+                visit(child, func)
+
+        visit(tree, "<module>")
+        return writes
+
+    def test_no_conn_state_writes_outside_connection_fsm(self):
+        """Spec AC-1 grep target: no `self._conn_state = ` assignment exists outside connection_fsm.py."""
+        for path in sorted(_SRC_DIR.glob("*.py")):
+            if path.name == "connection_fsm.py":
+                continue
+            self.assertNotIn("self._conn_state", path.read_text(encoding="utf-8"), f"found in {path.name}")
+
+    def test_tv_state_writes_are_device_state_only_in_init_and_pairing(self):
+        """tv.py must never shadow-write the runtime connection state."""
+        tree = ast.parse((_SRC_DIR / "tv.py").read_text(encoding="utf-8"))
+        state_writes = 0
+        for func, target, value in self._attribute_writes(tree):
+            if not (isinstance(target.value, ast.Name) and target.value.id == "self"):
+                continue
+            # the FSM instance may only be created in __init__, never reassigned elsewhere
+            if target.attr == "_conn":
+                self.assertEqual(func, "__init__", f"self._conn reassigned in {func}")
+                self.assertTrue(
+                    isinstance(value, ast.Call)
+                    and isinstance(value.func, ast.Name)
+                    and value.func.id == "ConnectionFsm",
+                    "self._conn must be initialized with a ConnectionFsm instance",
+                )
+                continue
+            if isinstance(target.value, ast.Attribute):  # e.g. self._conn._state
+                self.fail(f"nested attribute write on self in {func}")
+            if target.attr != "_state":
+                continue
+            state_writes += 1
+            self.assertIn(
+                func, self._ALLOWED_DEVICE_STATE_WRITERS, f"runtime `self._state` write in disallowed method {func}"
+            )
+            self.assertTrue(
+                isinstance(value, ast.Attribute)
+                and isinstance(value.value, ast.Name)
+                and value.value.id == "DeviceState",
+                f"`self._state` in {func} must only be assigned DeviceState members",
+            )
+        self.assertGreater(state_writes, 0, "audit is broken: no self._state writes found at all")
+
+    def test_tv_never_writes_fsm_internals(self):
+        """No `self._conn.<attr> = ...` write exists in tv.py (apply() is the single writer)."""
+        tree = ast.parse((_SRC_DIR / "tv.py").read_text(encoding="utf-8"))
+        for func, target, _value in self._attribute_writes(tree):
+            inner = target.value
+            if (
+                isinstance(inner, ast.Attribute)
+                and inner.attr == "_conn"
+                and isinstance(inner.value, ast.Name)
+                and inner.value.id == "self"
+            ):
+                self.fail(f"write to FSM internals `self._conn.{target.attr}` in {func}")
+
+
+class ReconnectOwnerSupervisionTest(TvConnectionTestCase):
+    """Test-Plan item 9 (spec F11)."""
+
+    async def test_silently_dying_reconnect_owner_triggers_recovery(self):
+        """Exceptional completion without auth callback: error logged, ownership re-established."""
+        await self.atv.connect()
+        self.assertEqual(self.fake.keep_reconnecting_calls, 1)
+
+        with self.assertLogs("tv", level="ERROR") as logs:
+            self.fake.fail_reconnect_owner(PermissionError("cert file unreadable"))
+            # recovery: DISCONNECT_REQUESTED + CONNECT_REQUESTED -> fresh keep_reconnecting
+            await self._wait_for(lambda: self.fake.keep_reconnecting_calls == 2)
+
+        self.assertTrue(any("Reconnect owner terminated unexpectedly" in message for message in logs.output))
+        self.assertEqual(self.fake.async_connect_calls, 2, "a fresh initial connect must have run")
+        self.assertGreaterEqual(self.fake.disconnect_calls, 1, "recovery must go through DISCONNECT_REQUESTED")
+        self.assertEqual(self.atv.connection_state, ConnectionState.CONNECTED)
+
+    async def test_cancelled_reconnect_owner_triggers_nothing(self):
+        """A cancelled reconnect task is a deliberate stop: no recovery dispatches."""
+        await self.atv.connect()
+        assert self.fake._reconnect_task is not None
+
+        self.fake._reconnect_task.cancel()
+        await self._drain()
+
+        self.assertEqual(self.fake.keep_reconnecting_calls, 1)
+        self.assertEqual(self.fake.async_connect_calls, 1)
+        self.assertEqual(self.atv.connection_state, ConnectionState.CONNECTED)
+        self.assertEqual(self.events[Events.DISCONNECTED], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements **Phase 2** of [spec 001 — Connection lifecycle state machine](https://github.com/unfoldedcircle/integration-androidtv/blob/main/docs/specs/001-connection-lifecycle-state-machine.md): the runtime connection lifecycle of `AndroidTv` is now driven by the pure `ConnectionFsm` merged in Phase 1 (#154), on top of the Stage-1 reconnection fixes (#153).

## What changed, for a reviewer who knows the old `tv.py`

- The ~20 scattered `self._state = DeviceState.*` runtime writes in `connect()`, `disconnect()`, `_is_available_updated()` and the invalid-auth callback are gone. They are replaced by `_dispatch(Trigger.*)` — the single place `ConnectionFsm.apply()` is called — and a thin, defensive intent executor `_execute()` that performs all side effects (task starts, `keep_reconnecting`, Cast reconnect, event emission). Pairing/init keep using `DeviceState`; the setup flow is untouched.
- The old inline connect-retry loop is now `_initial_connect()`, spawned by the `START_INITIAL_CONNECT` intent and still guarded by `_connect_lock`; `connect()` keeps its awaitable `bool` contract.
- The racy `_is_available_updated` callback is reduced to a single trigger dispatch; transport loss arms a 1.5 s grace timer (provisional, `connection_fsm.RECONNECT_GRACE`) and the Stage-1 IP-rediscovery watcher via intents.
- New `Events.RECONNECTING` (emitted on transport loss; driver wiring is Phase 3, harmless no-op until then).
- New (spec **F11**): the `androidtvremote2` reconnect-owner task is supervised via a done-callback; if it dies silently (unexpected exception, no cancellation, no auth callback), an error is logged and ownership is re-established through the existing transition table (`DISCONNECT_REQUESTED` → `CONNECT_REQUESTED`).

## Invariants / acceptance criteria implemented and tested

INV-1 single writer (AST audit test), INV-2 single reconnect owner (P0-2 regression test), INV-3 state/event coherence (single emit call site), INV-4 liveness-not-`is_on` (P0-3 regression test), INV-5 no flicker (grace-window tests), INV-6 terminal `AUTH_ERROR`/`UNREACHABLE`, INV-7 deterministic teardown; AC-1…AC-7, **AC-9** (new `tests/test_tv_connection.py`: 18 tests with a fake `AndroidTVRemote`, no network, no real sleeps — grace tested by dispatching `GRACE_ELAPSED` directly), AC-11.

## Deviations from the spec (fed back as spec edits in this PR, per the specs README)

1. **Already-connected fast path re-emit** kept, but routed through the executor's emit helper and gated on FSM state == `CONNECTED`, so the single-emit-call-site and state/event coherence hold.
2. **Setup-flow `DeviceState` read after `connect()`:** `setup_flow.py:552` also reads `.state` after `connect(timeout)`, which the spec's analysis missed. Not a regression — on `main` that read was always masked to `DISCONNECTED` by the preceding `disconnect()` write; with Phase 2, init/pairing auth/timeout classification now actually survives to the read (equal or better).

Minor intended behaviour notes for the reviewer: `CONNECT_ABORTED` now emits `DISCONNECTED` (old code emitted nothing on abort); an idempotent `disconnect()` from `DISCONNECTED` no longer emits; a command during a failed *pairing* now returns `SERVICE_UNAVAILABLE` instead of `CONFLICT` (`PAIRING_ERROR` is a pairing-lifecycle state, out of FSM scope).

## Verification

- `python -m unittest discover tests` — **92/92** pass (74 pre-existing unchanged + 18 new); run 5× consecutively, stable
- `black` / `isort` / `flake8` clean, `pylint` 10.00/10

Phase 3 (driver event-contract cleanup, wiring `RECONNECTING` to the UI) follows as a small standalone PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

