### PR TITLE
ci: set persist-credentials: false on checkout steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -60,6 +62,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           # History of 200 should be more than enough to calculate commit count since last release tag.
           fetch-depth: 200
 
@@ -131,6 +134,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -190,6 +194,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           path: main
 
       # We have to delete the "latest" release, otherwise `softprops/action-gh-release` will only append the new artifact.

--- a/.github/workflows/python-code-format.yml
+++ b/.github/workflows/python-code-format.yml
@@ -32,6 +32,8 @@ jobs:
     name: Check Python code formatting
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
# Description

Pinned actions

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Not testable / tested via CI

# Checklist:

- [x] My code follows the [code guidelines](https://github.com/unfoldedcircle/integration-androidtv/blob/main/docs/code_guidelines.md) of this project
- [x] My pull request represents one logical piece of work. Do not combine multiple unrelated changes into a single pull request.
- [x] My changes pass the linter checks (see [code guidelines](https://github.com/unfoldedcircle/integration-androidtv/blob/main/docs/code_guidelines.md)) and unit tests `python -m unittest discover tests`. PRs with failing linter or unit tests will not be merged.
- [x] I have tested and performed a self-review of my code
